### PR TITLE
Remove registration of OS hooks

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -21,14 +21,6 @@
 /* Create ACLs for main box. */
 MAIN_ACL(g_main_acl);
 
-/* Register privleged system IRQ hooks. */
-extern "C" void SVC_Handler(void);
-extern "C" void PendSV_Handler(void);
-extern "C" void SysTick_Handler(void);
-extern "C" uint32_t rt_suspend(void);
-
-UVISOR_SET_PRIV_SYS_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler, rt_suspend);
-
 /* Enable uVisor. */
 UVISOR_SET_MODE_ACL(UVISOR_ENABLED, g_main_acl);
 UVISOR_SET_PAGE_HEAP(8*1024, 5);


### PR DESCRIPTION
uvisor-lib now registers the OS with uVisor, so we don't have to.

@meriac @AlessandroA @niklas-arm
