### PR TITLE
Specify blacklisted platforms in a json file

### DIFF
--- a/test/filters.json
+++ b/test/filters.json
@@ -1,0 +1,6 @@
+{
+    "blacklist" : [ {
+        "platforms" : ["EFM32GG_STK3700"]
+        }
+    ]
+}


### PR DESCRIPTION
uVisor examples by default support all platforms supported by
uvisor-tests. This file contains a blacklist to filter out
platforms unsupported by this example.