### PR TITLE
Note on exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ When a debugger is connected, you can observe debug output from uVisor. Please n
 ```bash
 $ mbed compile -m K64F -t GCC_ARM --profile mbed-os/tools/profiles/debug.json -c
 ```
+
+## Known problems
+
+- Use of exporters for multiple IDE is not supported at the moment
+


### PR DESCRIPTION
Adding note on the example not supporting exporters to IDE.

Consider extending this to other uvisor examples

@AlessandroA